### PR TITLE
execution time and plan analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,15 @@ runs the prototype
 The script ``` analyzer/commandline_wrapper.py ``` is able to analyze outputs of the following planners: [Jasper](https://www.semanticscholar.org/paper/Jasper-%3A-the-Art-of-Exploration-in-Greedy-Best-Xie-M%C3%BCller/70b994eee371224a4530b602118cfc556c309f4b) and [Fast Downward](http://www.fast-downward.org/). Support for Marvin might be added in the future.  
 
 ### Usage
-The analyzer can be used by piping the output to the script.   
-Example: ``` cat output_file | python3 commandline_wrapper.py ```      
-Multiple outputs of different planners can be merged in a single file. But above each output a line has to be added which tells the analyzer what kind of planner has produced the output.   
-Example for a single Fast Downward output file:      
+The analyzer can be used by piping the output to the script. Example: ``` cat output_file | python3 commandline_wrapper.py ```. Multiple outputs of different planners can be merged in a single file. But above each output a line has to be added which tells the analyzer what kind of planner has produced the output.   
+Example for a single Fast Downward output:      
 ```
 <<<<FD>>>>
 INFO     Running translator.
 INFO     translator stdin: None
 ...
 ```
-Example for a single Jasper output file:      
+Example for a single Jasper output:      
 ```
 <<<<JASPER>>>>
 1. Running translator

--- a/README.md
+++ b/README.md
@@ -27,3 +27,25 @@ installes all necessary requirements for python3
 python3 main.py
 ```
 runs the prototype
+
+## Analyzer
+The script ``` analyzer/commandline_wrapper.py ``` is able to analyze outputs of the following planners: [Jasper](https://www.semanticscholar.org/paper/Jasper-%3A-the-Art-of-Exploration-in-Greedy-Best-Xie-M%C3%BCller/70b994eee371224a4530b602118cfc556c309f4b) and [Fast Downward](http://www.fast-downward.org/). Support for Marvin might be added in the future.  
+
+### Usage
+The analyzer can be used by piping the output to the script.   
+Example: ``` cat output_file | python3 commandline_wrapper.py ```      
+Multiple outputs of different planners can be merged in a single file. But above each output a line has to be added which tells the analyzer what kind of planner has produced the output.   
+Example for a single Fast Downward output file:      
+```
+<<<<FD>>>>
+INFO     Running translator.
+INFO     translator stdin: None
+...
+```
+Example for a single Jasper output file:      
+```
+<<<<JASPER>>>>
+1. Running translator
+Parsing... [0.000s CPU, 0.003s wall-clock]
+...
+```

--- a/analyzer/commandline_wrapper.py
+++ b/analyzer/commandline_wrapper.py
@@ -30,6 +30,10 @@ def parse_planner_output(output):
 		report = reader.parse_output(output)
 		print(report)
 
+	reader = Jasper_Output_Reader()
+	for output in jasper_output_list:
+		report = reader.parse_output(output)
+		print(report)
 
 content = ""
 for line in fileinput.input():

--- a/analyzer/commandline_wrapper.py
+++ b/analyzer/commandline_wrapper.py
@@ -1,0 +1,13 @@
+import fileinput
+from output_reader import Output_Reader
+from fast_downward_output_reader import Fast_Downward_Output_Reader
+
+content = ""
+for line in fileinput.input():
+	content += line
+
+# start utility
+reader = Fast_Downward_Output_Reader()
+report = reader.parse_output(content)
+
+print(str(report))

--- a/analyzer/commandline_wrapper.py
+++ b/analyzer/commandline_wrapper.py
@@ -1,13 +1,38 @@
 import fileinput
+import re
 from output_reader import Output_Reader
 from fast_downward_output_reader import Fast_Downward_Output_Reader
+from jasper_output_reader import Jasper_Output_Reader
+
+def parse_planner_output(output):
+	# split outputs by delimiter e.g. <<<<FD>>>> or <<<<JASPER>>>>
+	fd_output_list = []
+	jasper_output_list = []
+	current_output = None
+	for line in output.splitlines():
+		if line.startswith("<<<<FD>>>>"):
+			current_output = "FD"
+			fd_output_list.append("")
+		elif line.startswith("<<<<JASPER>>>>"):
+			current_output = "JASPER"
+			jasper_output_list.append("")
+
+		if current_output == "FD":
+				fd_output_list[len(fd_output_list)-1] += line + "\n"
+		elif current_output == "JASPER":
+				jasper_output_list[len(jasper_output_list)-1] += line + "\n"
+
+	print("number fd outputs: " + str(len(fd_output_list)))
+	print("number jasper outputs: " + str(len(jasper_output_list)))
+
+	reader = Fast_Downward_Output_Reader()
+	for output in fd_output_list:
+		report = reader.parse_output(output)
+		print(report)
+
 
 content = ""
 for line in fileinput.input():
 	content += line
 
-# start utility
-reader = Fast_Downward_Output_Reader()
-report = reader.parse_output(content)
-
-print(str(report))
+parse_planner_output(content)

--- a/analyzer/fast_downward_output_reader.py
+++ b/analyzer/fast_downward_output_reader.py
@@ -1,26 +1,49 @@
 from output_reader import Output_Reader
 from output_reader import Parslet
 from report import Report
+from report import Plan
+import re
 
 class Fast_Downward_Output_Reader(Output_Reader):
 
 	planner_name = "fast_downward"
 
 	def init(self, output):
-		self.report = Report("test", self.planner_name)
+		self.report = Report("fast_downward", self.planner_name)
+		self.parslets = [Parslet(self.parse_plan, "Solution found!", "Plan cost:"), 
+				Parslet(self.parse_time, "Search time:"),
+				Parslet(self.parse_arguments, "INFO     search command line string:")]
 
-	def parse_plan(plan_string):
-		pass
+	# Example parslet:
+	# 	Solution found!
+	# 	Actual search time: 4.8324s [t=4.84568s]
+	# 	change_type ubuntu1 ubuntu-12xx04 ubuntu-18xx04 (1)
+	# 	...
+	# 	change_type java-runtime0 java_runtime-6 java_runtime-8 (1)
+	# 	Plan length: 5 step(s).
+	# 	Plan cost: 5
+	def parse_plan(self, args):
+		self.solution_found = True
+		lines = args.splitlines()
+		exec_time = re.search(r'\d+\.\d+', lines[1]).group(0)
+		plan_length = re.findall(r'\d', lines[-2])[0]
+		plan_cost = re.findall(r'\d', lines[-1])[0]
+		actions = ""
+		for i in range(2,len(lines)-2):
+			actions += re.sub(r'\(.*\)', "", lines[i]) + "\n"
+		plan = Plan(exec_time, plan_length, plan_cost, actions, str(len(self.report.plans)))
+		self.report.plans.append(plan)
 		
+		
+	# Example parslet:
+	#	Search time: 4.83256s
+	def parse_time(self, args):
+		lines = args.splitlines()
+		search_time = re.search(r'\d+\.\d+', lines[0]).group(0)		
+		self.report.execution_time = search_time
 
-	def parse_whole_result(result_string):
-		pass
-
-	def parse_arguments(argument_string):
-		pass
-
-
-	parslets = [Parslet(parse_plan, "Solution found!", "Plan cost:"), 
-				Parslet(parse_whole_result, "Search time:", "Solution found."),
-				Parslet(parse_arguments, "INFO     search command line string:")]
-	parslets_dict = {}
+	# Example parslet:
+	# INFO     search command line string: /some/path/downward --search 'astar(blind())' 
+	def parse_arguments(self, args):
+		argument_list = args.split()[6:]
+		self.report.planner_arguments = " ".join(argument_list)

--- a/analyzer/fast_downward_output_reader.py
+++ b/analyzer/fast_downward_output_reader.py
@@ -1,5 +1,5 @@
 from output_reader import Output_Reader
-from output_reader import Parslet
+from parslet import Parslet
 from report import Report
 from report import Plan
 import re
@@ -8,7 +8,7 @@ class Fast_Downward_Output_Reader(Output_Reader):
 
 	planner_name = "fast_downward"
 
-	def init(self, output):
+	def __init__(self):
 		self.report = Report("fast_downward", self.planner_name)
 		self.parslets = [Parslet(self.parse_plan, "Solution found!", "Plan cost:"), 
 				Parslet(self.parse_time, "Search time:"),
@@ -25,7 +25,6 @@ class Fast_Downward_Output_Reader(Output_Reader):
 	def parse_plan(self, args):
 		self.solution_found = True
 		lines = args.splitlines()
-		print(lines)
 		exec_time = re.search(r'\d+\.\d+', lines[1]).group(0)
 		plan_length = re.findall(r'\d', lines[-2])[0]
 		plan_cost = re.findall(r'\d', lines[-1])[0]
@@ -40,6 +39,8 @@ class Fast_Downward_Output_Reader(Output_Reader):
 	#	Search time: 4.83256s
 	def parse_time(self, args):
 		lines = args.splitlines()
+		if(len(lines) != 1): return
+
 		search_time = re.search(r'\d+\.\d+', lines[0]).group(0)		
 		self.report.execution_time = search_time
 

--- a/analyzer/fast_downward_output_reader.py
+++ b/analyzer/fast_downward_output_reader.py
@@ -25,6 +25,7 @@ class Fast_Downward_Output_Reader(Output_Reader):
 	def parse_plan(self, args):
 		self.solution_found = True
 		lines = args.splitlines()
+		print(lines)
 		exec_time = re.search(r'\d+\.\d+', lines[1]).group(0)
 		plan_length = re.findall(r'\d', lines[-2])[0]
 		plan_cost = re.findall(r'\d', lines[-1])[0]

--- a/analyzer/fast_downward_output_reader.py
+++ b/analyzer/fast_downward_output_reader.py
@@ -1,13 +1,26 @@
 from output_reader import Output_Reader
+from output_reader import Parslet
 from report import Report
 
 class Fast_Downward_Output_Reader(Output_Reader):
 
 	planner_name = "fast_downward"
 
-	def parse_output(self, output):
-		report = Report("test", self.planner_name)
+	def init(self, output):
+		self.report = Report("test", self.planner_name)
+
+	def parse_plan(plan_string):
+		pass
+		
+
+	def parse_whole_result(result_string):
+		pass
+
+	def parse_arguments(argument_string):
+		pass
 
 
-		return report
-
+	parslets = [Parslet(parse_plan, "Solution found!", "Plan cost:"), 
+				Parslet(parse_whole_result, "Search time:", "Solution found."),
+				Parslet(parse_arguments, "INFO     search command line string:")]
+	parslets_dict = {}

--- a/analyzer/fast_downward_output_reader.py
+++ b/analyzer/fast_downward_output_reader.py
@@ -1,0 +1,13 @@
+from output_reader import Output_Reader
+from report import Report
+
+class Fast_Downward_Output_Reader(Output_Reader):
+
+	planner_name = "fast_downward"
+
+	def parse_output(self, output):
+		report = Report("test", self.planner_name)
+
+
+		return report
+

--- a/analyzer/fast_downward_output_reader.py
+++ b/analyzer/fast_downward_output_reader.py
@@ -31,7 +31,8 @@ class Fast_Downward_Output_Reader(Output_Reader):
 		actions = ""
 		for i in range(2,len(lines)-2):
 			actions += re.sub(r'\(.*\)', "", lines[i]) + "\n"
-		plan = Plan(exec_time, plan_length, plan_cost, actions, str(len(self.report.plans)))
+		plan = Plan(exec_time, plan_length, 
+			actions, cost=plan_cost, name=str(len(self.report.plans)))
 		self.report.plans.append(plan)
 		
 		

--- a/analyzer/jasper_output_reader.py
+++ b/analyzer/jasper_output_reader.py
@@ -1,4 +1,62 @@
 from output_reader import Output_Reader
+from output_reader import Parslet
+from report import Report
+from report import Plan
+import re
 
 class Jasper_Output_Reader(Output_Reader):
+
 	planner_name = "jasper"
+
+	def init(self, output):
+		self.report = Report("jasper", self.planner_name)
+		self.parslets = [Parslet(self.parse_plan, "Starting search:", "Starting search:"),
+		Parslet(self.parse_time, "Search time:")]
+
+	# Example parslet:
+	# 	Solution found!
+	# 	Actual search time: 4.8324s [t=4.84568s]
+	# 	change_type ubuntu1 ubuntu-12xx04 ubuntu-18xx04 (1)
+	# 	...
+	# 	change_type java-runtime0 java_runtime-6 java_runtime-8 (1)
+	# 	Plan length: 5 step(s).
+	# 	Plan cost: 5
+	def parse_plan(self, args):
+		if(not "plan_id" in args): return
+
+		self.solution_found = True
+		lines = args.splitlines()
+		exec_time = -1
+		plan_length = -1
+		plan_cost = -1
+		plan_start_index = 0
+		plan_end_index = 0
+		counter = 0
+		for line in lines:
+			if("Real Total time" in line):
+				plan_start_index = counter+1
+			elif("Plan length" in line):
+				plan_end_index = counter
+				plan_length = re.findall(r'\d', line)[0]
+			elif("Plan cost" in line):
+				plan_cost = re.findall(r'\d', line)[0]
+			elif("Actual search time:" in line):
+				exec_time = re.findall(r'\d+\.\d+', line)[0]
+			counter+=1				
+
+		actions = "\n".join(lines[plan_start_index:plan_end_index])
+		plan = Plan(exec_time, plan_length, plan_cost, actions, str(len(self.report.plans)))
+		self.report.plans.append(plan)
+
+	# Example parslet:
+	#	Search time: 4.83256s
+	def parse_time(self, args):
+		search_time = re.search(r'\d+\.\d+', args).group(0)		
+		self.report.execution_time = search_time
+
+
+
+
+
+		
+		

--- a/analyzer/jasper_output_reader.py
+++ b/analyzer/jasper_output_reader.py
@@ -42,10 +42,11 @@ class Jasper_Output_Reader(Output_Reader):
 				plan_cost = re.findall(r'\d', line)[0]
 			elif("Actual search time:" in line):
 				exec_time = re.findall(r'\d+\.\d+', line)[0]
-			counter+=1				
+			counter+=1			
 
 		actions = "\n".join(lines[plan_start_index:plan_end_index])
-		plan = Plan(exec_time, plan_length, plan_cost, actions, str(len(self.report.plans)))
+		plan = Plan(exec_time, plan_length, 
+			actions, cost=plan_cost, name=str(len(self.report.plans)))
 		self.report.plans.append(plan)
 
 	# Example parslet:

--- a/analyzer/jasper_output_reader.py
+++ b/analyzer/jasper_output_reader.py
@@ -1,5 +1,5 @@
 from output_reader import Output_Reader
-from output_reader import Parslet
+from parslet import Parslet
 from report import Report
 from report import Plan
 import re
@@ -8,7 +8,7 @@ class Jasper_Output_Reader(Output_Reader):
 
 	planner_name = "jasper"
 
-	def init(self, output):
+	def __init__(self):
 		self.report = Report("jasper", self.planner_name)
 		self.parslets = [Parslet(self.parse_plan, "Starting search:", "Starting search:"),
 		Parslet(self.parse_time, "Search time:")]
@@ -35,7 +35,7 @@ class Jasper_Output_Reader(Output_Reader):
 		for line in lines:
 			if("Real Total time" in line):
 				plan_start_index = counter+1
-			elif("Plan length" in line):
+			elif("Plan length" in line and plan_end_index == 0):
 				plan_end_index = counter
 				plan_length = re.findall(r'\d', line)[0]
 			elif("Plan cost" in line):

--- a/analyzer/jasper_output_reader.py
+++ b/analyzer/jasper_output_reader.py
@@ -1,0 +1,4 @@
+from output_reader import Output_Reader
+
+class Jasper_Output_Reader(Output_Reader):
+	planner_name = "jasper"

--- a/analyzer/output_reader.py
+++ b/analyzer/output_reader.py
@@ -1,4 +1,56 @@
 class Output_Reader:
 
-	def parse_output():
-		pass
+	parslets = {}
+	report = None
+
+	def init(self, output):
+		pass 
+
+	# calls the specified function for the parslet
+	def parse_parslet(self, parslet):
+		parslet.function_to_call(parslet.string_to_parse)
+
+	# this function finds the parslet snippets in the output string of the planner
+	# in which we are interested in
+	# each parslet has a string which describes the start of a parslet
+	# and the end of a parslet. The string is a prefix of the specific line
+	def parse_output(self, output):
+		self.init(output)
+
+		self.parslets_dict = {parslet.starts_with:parslet for parslet in self.parslets}
+
+		list_open_parslets = []
+		list_complete_parslets = []
+		for line in output.splitlines():
+			for prefix in self.parslets_dict.keys():
+				if line.startswith(prefix):
+					list_open_parslets.append(self.parslets_dict[prefix])
+
+			for open_parslet in list_open_parslets:
+				if line.startswith(open_parslet.ends_with):
+					list_open_parslets.remove(open_parslet)
+					list_complete_parslets.append(open_parslet)
+				open_parslet.string_to_parse += line + "\n"
+
+		for parslet in list_complete_parslets:
+			self.parse_parslet(parslet)
+
+		return self.report
+
+# parslets describe the part of the output we are interested in and the correct function
+# to parse this part of the planner output
+class Parslet:
+
+	starts_with = None
+	ends_with = None
+	function_to_call = None
+	string_to_parse = ""
+
+	def __init__(self, function_to_call, starts_with, ends_with=None):
+		self.starts_with = starts_with
+		# if no end is given, only one line will be considered
+		if ends_with:
+			self.ends_with = ends_with
+		else:
+			self.ends_with = starts_with
+		self.function_to_call = function_to_call

--- a/analyzer/output_reader.py
+++ b/analyzer/output_reader.py
@@ -1,6 +1,7 @@
 class Output_Reader:
 
 	parslets = {}
+	parslets_dict = {}
 	report = None
 
 	def init(self, output):

--- a/analyzer/output_reader.py
+++ b/analyzer/output_reader.py
@@ -33,9 +33,9 @@ class Output_Reader:
 						# does the current line satisfy the stopping condition?
 						if line.startswith(parslet.last_line_prefix):
 							parslet.save_snippet()
-				else:
-					if line.startswith(parslet.prefix):
-						parslet.append_to_snippet(line + "\n")
+							
+				if line.startswith(parslet.prefix):
+					parslet.append_to_snippet(line + "\n")
 
 		for parslet in self.parslets:
 			self.parse_parslet(parslet)

--- a/analyzer/output_reader.py
+++ b/analyzer/output_reader.py
@@ -1,0 +1,4 @@
+class Output_Reader:
+
+	def parse_output():
+		pass

--- a/analyzer/output_reader.py
+++ b/analyzer/output_reader.py
@@ -1,18 +1,15 @@
+from parslet import Parslet
 import uuid
 
 class Output_Reader:
 
-	parslets = {}
-	parslets_dict = {}
-	report = None
-
-	def init(self, output):
-		pass 
+	def __init__(self):
+		self.parslets = []
+		self.report = None
 
 	# calls the specified function for the parslet
 	def parse_parslet(self, parslet):
-		if(len(parslet.snippets_to_parse) == 0): 
-			return
+		if(len(parslet.snippets_to_parse) == 0): return
 
 		for snippet in parslet.snippets_to_parse:
 			parslet.function_to_call(snippet)
@@ -22,53 +19,25 @@ class Output_Reader:
 	# each parslet has a string which describes the start of a parslet
 	# and the end of a parslet. The string is a prefix of the specific line
 	def parse_output(self, output):
-		self.init(output)
-
-		self.parslets_dict = {parslet.prefix:parslet for parslet in self.parslets}
-
-		open_parslets = []
 		for line in output.splitlines():
-			for open_parslet in open_parslets:
-				open_parslet.append_to_snippet(line + "\n")
+			for parslet in self.parslets:
+				# only look at parslets which already contain partial snippets
+				if parslet.partial_snippet:
+					# parslet does not have a stopping condition 
+					# -> finish after first line
+					if not parslet.last_line_prefix:
+						parslet.save_snippet()
+					else:
+						parslet.append_to_snippet(line + "\n")
 
-				if line.startswith(open_parslet.last_line_prefix):
-					if(not (open_parslet.prefix == open_parslet.last_line_prefix and 
-						len(open_parslet.partial_snippet.splitlines()) == 1)):
-						open_parslet.save_snippet()
-						open_parslets.remove(open_parslet)
+						# does the current line satisfy the stopping condition?
+						if line.startswith(parslet.last_line_prefix):
+							parslet.save_snippet()
+				else:
+					if line.startswith(parslet.prefix):
+						parslet.append_to_snippet(line + "\n")
 
-			for prefix in self.parslets_dict.keys():
-				if (line.startswith(prefix) and 
-					not self.parslets_dict[prefix] in open_parslets):
-					self.parslets_dict[prefix].append_to_snippet(line + "\n")
-					open_parslets.append(self.parslets_dict[prefix])
-
-		for parslet in self.parslets_dict.values():
+		for parslet in self.parslets:
 			self.parse_parslet(parslet)
 
 		return self.report
-
-# parslets describe the part of the output we are interested in and the correct function
-# to parse this part of the planner output
-class Parslet:
-	prefix = None
-	last_line_prefix = None
-	function_to_call = None
-	snippets_to_parse = []
-	partial_snippet = ""
-
-	def __init__(self, function_to_call, prefix, last_line_prefix=None):
-		self.prefix = prefix
-		# if no end is given, only one line will be considered
-		if last_line_prefix:
-			self.last_line_prefix = last_line_prefix
-		else:
-			self.last_line_prefix = prefix
-		self.function_to_call = function_to_call
-
-	def append_to_snippet(self, content):
-		self.partial_snippet += content
-
-	def save_snippet(self):
-		self.snippets_to_parse.append(self.partial_snippet)
-		self.partial_snippet = ""

--- a/analyzer/parslet.py
+++ b/analyzer/parslet.py
@@ -1,0 +1,25 @@
+# parslets describe the part of the output we are interested in and the correct function
+# to parse this part of the planner output
+class Parslet:
+
+	def __init__(self, function_to_call, prefix, last_line_prefix=None):
+		self.prefix = prefix
+		# if no end is given, only one line will be considered
+		if last_line_prefix:
+			self.last_line_prefix = last_line_prefix
+		else:
+			self.last_line_prefix = None
+
+		self.function_to_call = function_to_call
+		self.snippets_to_parse = []
+		self.partial_snippet = None
+
+
+	def append_to_snippet(self, content):
+		if not self.partial_snippet:
+			self.partial_snippet = ""
+		self.partial_snippet += content
+
+	def save_snippet(self):
+		self.snippets_to_parse.append(self.partial_snippet)
+		self.partial_snippet = None

--- a/analyzer/report.py
+++ b/analyzer/report.py
@@ -1,11 +1,20 @@
 class Plan:
 
-	def __init__(self, name, execution_time, number_steps, steps):
+	def __init__(self, execution_time, number_steps, cost, actions, name=""):
 		self.name = name
 		# time in seconds!
 		self.execution_time = execution_time
 		self.number_steps = number_steps
-		self.steps = steps
+		self.cost = cost
+		self.actions = actions
+
+	def __str__(self):
+		res =  ("PLAN " + self.name + "\n" 
+			+ "exec time " + self.execution_time + "s\n" 
+			+ "number steps " + self.number_steps + "\n")
+		for action in self.actions.splitlines():
+			res += action + "\n"
+		return res
 
 class Report:
 
@@ -25,9 +34,10 @@ class Report:
 	def nth_plan_by_exec_time(self, n):
 		# array starts with zero
 		n = n-1
+		if n >= len(self.plans)-1: n = len(self.plans)-1
 		execution_times = {plan.execution_time:plan for plan in self.plans}
-		result_key = execution_times.keys().sort()[n]
-		return execution_times[result_key]
+		result_key = sorted([float(k) for k in execution_times])[n]
+		return execution_times[str(result_key)]
 
 	# calculates for n=1 plan with fewest steps
 	# for n = len(self.plans) plan with the most steps
@@ -35,39 +45,48 @@ class Report:
 	def nth_plan_by_steps(self, n):
 		# array starts with zero
 		n = n-1
+		if n >= len(self.plans)-1: n = len(self.plans)-1
 		execution_times = {plan.number_steps:plan for plan in self.plans}
-		result_key = execution_times.keys().sort()[n]
-		return execution_times[result_key]
+		result_key = sorted([int(k) for k in execution_times])[n]
+		return execution_times[str(result_key)]
 
 	def add_line(self, line):
-		return line + "\n"
-
-	def add_indented_line(self, line):
 		return "\t" + line + "\n"
 
+	def add_indented_line(self, line):
+		return "\t" + self.add_line(line)
+
 	def __str__(self):
-		rep = ""
-		if self.name: rep += self.add_line("REPORT " + self.name)
+		rep = "REPORT \n"
+		if self.name: rep += self.add_line("name: " + self.name)
 		if self.planner_name: rep += self.add_line("using planner: " + self.planner_name)
-		if self.planner_arguments: rep += self.add_line("parameters: " + self.parameters)
+		if self.planner_arguments: rep += self.add_line("parameters: " + self.planner_arguments)
 		if self.solution_found: rep += self.add_line("solution found")
-		if self.execution_time: rep += self.add_line("whole execution time: " + self.execution_time)
+		if self.execution_time: rep += self.add_line("whole execution time: " + self.execution_time +"s")
 
 		# prints fastest and slowest plan
 		if len(self.plans) > 0:
-			rep += self.add_line("FASTEST PLAN:")
-			rep += self.add_indented_line(str(self.nth_plan_by_exec_time(1)))
+			rep += self.add_line("FASTEST PLAN TO CALCULATE:")
+			plan = str(self.nth_plan_by_exec_time(1))
+			for line in plan.splitlines():
+				rep += self.add_indented_line(line)
 		elif len(self.plans) > 1:
 			rep += self.add_line("SLOWEST PLAN:")
-			rep += self.add_indented_line(str(self.nth_plan_by_exec_time(len(self.plans))))
+			plan = str(self.nth_plan_by_exec_time(1))
+			for line in plan.splitlines():
+				rep += self.add_indented_line(line)
 
 		# prints plans with most and fewest steps
 		if len(self.plans) > 0:
 			rep += self.add_line("FEWEST STEPS PLAN:")
-			rep += self.add_indented_line(str(self.nth_plan_by_steps(1)))
+			plan = str(self.nth_plan_by_steps(1))
+			for line in plan.splitlines():
+				rep += self.add_indented_line(line)
 		elif len(self.plans) > 1:
 			rep += self.add_line("MOST STEPS PLAN:")
-			rep += self.add_indented_line(str(self.nth_plan_by_steps(len(self.plans))))
+			plan = str(self.nth_plan_by_steps(1))
+			for line in plan.splitlines():
+				rep += self.add_indented_line(line)
 
 		return rep
 

--- a/analyzer/report.py
+++ b/analyzer/report.py
@@ -1,19 +1,25 @@
 class Plan:
 
-	def __init__(self, execution_time, number_steps, cost, actions, name=""):
+	def __init__(self, execution_time, number_steps, 
+				actions, cost="", name="", arguments=""):
 		self.name = name
 		# time in seconds!
 		self.execution_time = execution_time
 		self.number_steps = number_steps
 		self.cost = cost
 		self.actions = actions
+		self.arguments = arguments
 
 	def __str__(self):
-		res =  ("PLAN " + self.name + "\n" 
-			+ "exec time " + self.execution_time + "s\n" 
-			+ "number steps " + self.number_steps + "\n")
+		res =  ("PLAN " + self.name + "\n"
+			+ "exec time " + str(self.execution_time) + "s\n"
+			+ "number steps " + str(self.number_steps) + "\n")
+
+		if self.arguments != "":
+			res += "arguments " + self.arguments + "\n"
+
 		for action in self.actions.splitlines():
-			res += action + "\n"
+			res += "\t" + action + "\n"
 		return res
 
 class Report:
@@ -51,7 +57,7 @@ class Report:
 		return execution_times[str(result_key)]
 
 	def add_line(self, line):
-		return "\t" + line + "\n"
+		return line + "\n"
 
 	def add_indented_line(self, line):
 		return "\t" + self.add_line(line)

--- a/analyzer/report.py
+++ b/analyzer/report.py
@@ -1,0 +1,76 @@
+class Plan:
+
+	def __init__(self, name, execution_time, number_steps, steps):
+		self.name = name
+		# time in seconds!
+		self.execution_time = execution_time
+		self.number_steps = number_steps
+		self.steps = steps
+
+class Report:
+
+	def __init__(self, name, planner_name):
+		self.name = name
+		self.planner_name = planner_name
+
+		self.planner_arguments = None
+		self.solution_found = False
+		self.execution_time = None
+
+		self.plans = []
+
+	# calculates for n=1 fastest plan
+	# for n = len(self.plans) the slowest plan
+	# for n = 2 the 2nd fastest plan etc
+	def nth_plan_by_exec_time(self, n):
+		# array starts with zero
+		n = n-1
+		execution_times = {plan.execution_time:plan for plan in self.plans}
+		result_key = execution_times.keys().sort()[n]
+		return execution_times[result_key]
+
+	# calculates for n=1 plan with fewest steps
+	# for n = len(self.plans) plan with the most steps
+	# for n = 2 the plant with 2nd fewest steps etc
+	def nth_plan_by_steps(self, n):
+		# array starts with zero
+		n = n-1
+		execution_times = {plan.number_steps:plan for plan in self.plans}
+		result_key = execution_times.keys().sort()[n]
+		return execution_times[result_key]
+
+	def add_line(self, line):
+		return line + "\n"
+
+	def add_indented_line(self, line):
+		return "\t" + line + "\n"
+
+	def __str__(self):
+		rep = ""
+		if self.name: rep += self.add_line("REPORT " + self.name)
+		if self.planner_name: rep += self.add_line("using planner: " + self.planner_name)
+		if self.planner_arguments: rep += self.add_line("parameters: " + self.parameters)
+		if self.solution_found: rep += self.add_line("solution found")
+		if self.execution_time: rep += self.add_line("whole execution time: " + self.execution_time)
+
+		# prints fastest and slowest plan
+		if len(self.plans) > 0:
+			rep += self.add_line("FASTEST PLAN:")
+			rep += self.add_indented_line(str(self.nth_plan_by_exec_time(1)))
+		elif len(self.plans) > 1:
+			rep += self.add_line("SLOWEST PLAN:")
+			rep += self.add_indented_line(str(self.nth_plan_by_exec_time(len(self.plans))))
+
+		# prints plans with most and fewest steps
+		if len(self.plans) > 0:
+			rep += self.add_line("FEWEST STEPS PLAN:")
+			rep += self.add_indented_line(str(self.nth_plan_by_steps(1)))
+		elif len(self.plans) > 1:
+			rep += self.add_line("MOST STEPS PLAN:")
+			rep += self.add_indented_line(str(self.nth_plan_by_steps(len(self.plans))))
+
+		return rep
+
+
+
+

--- a/pddl/domain.pddl
+++ b/pddl/domain.pddl
@@ -1,5 +1,5 @@
 (define (domain deployment_domain)
-	(:requirements :typing :derived-predicates :strips :existential-preconditions :equality)
+	(:requirements :typing :derived-predicates :strips :equality)
 	(:types component_type abstract_component_type component reqcap)
 	(:constants )
 	(:predicates 


### PR DESCRIPTION
Adds features which lets users pipe the output from different planners to commandline_wrapper.py which generates a generic report about the execution time, plans found etc. The class reads directly form stdin.

For Example:
`python3 fast_downward.py domain.pddl fast_solvable_problem.pddl --search "astar(blind())" | python3 ../analyzer/commandline_wrapper.py`

This enables users to compare planners in an easier manner. Reports can also be read from main code, which might be useful in the future. For example for plotting graphs automatically or to analyze multiple planners / different planner arguments in a generic way.

Todo:
- [x] structure for parsing and report outputs
- [x] fast downward output parser
- [x] jasper output parser
- [ ] find out which information is actually useful